### PR TITLE
Added default type parameters

### DIFF
--- a/Sources/DIContainer/DIContainer.swift
+++ b/Sources/DIContainer/DIContainer.swift
@@ -20,11 +20,11 @@ public class DIContainer: DIContainerProtocol {
         self.dependencies[self.key(for: type)] = value
     }
     
-    public func has<Protocol>(type: Protocol.Type) -> Bool {
+    public func has<Protocol>(type: Protocol.Type = Protocol.self) -> Bool {
         return self.dependencies.index(forKey: self.key(for: type)) != nil
     }
     
-    public subscript<Protocol>(_ type: Protocol.Type) -> Protocol? {
+    public subscript<Protocol>(_ type: Protocol.Type = Protocol.self) -> Protocol? {
         get {
             guard let lifecycle = self.dependencies[self.key(for: type)] as? DILifecycle<Protocol> else {
                 return nil

--- a/Sources/DIContainer/DIContainerProtocol.swift
+++ b/Sources/DIContainer/DIContainerProtocol.swift
@@ -14,19 +14,23 @@ public protocol DIContainerProtocol {
 }
 
 extension DIContainerProtocol {
-    public func register<Protocol>(type: Protocol.Type, transient factory: @escaping DIFactory<Protocol>) {
+    public func register<Protocol>(type: Protocol.Type = Protocol.self, transient factory: @escaping DIFactory<Protocol>) {
         self.register(type: type, value: .transient(factory))
     }
     
-    public func register<Protocol>(type: Protocol.Type, lazySingleton factory: @escaping DIFactory<Protocol>) {
+    public func register<Protocol>(type: Protocol.Type = Protocol.self, lazySingleton factory: @escaping DIFactory<Protocol>) {
         self.register(type: type, value: .lazySingleton(DILazy(factory: factory)))
     }
     
-    public func register<Protocol>(type: Protocol.Type, eagerSingleton dependency: Protocol) {
+    public func register<Protocol>(type: Protocol.Type = Protocol.self, eagerSingleton dependency: Protocol) {
         self.register(type: type, value: .eagerSingleton(dependency))
     }
     
-    public func resolve<Protocol>(_ type: Protocol.Type) -> Protocol? {
+    public func resolve<Protocol>(_ type: Protocol.Type = Protocol.self) -> Protocol? {
         return self[type]
+    }
+    
+    public func forceResolve<Protocol>(_ type: Protocol.Type = Protocol.self) -> Protocol {
+        return self.resolve()!
     }
 }


### PR DESCRIPTION
This makes a nice `di.resolve()` call possible when the compiler can infer types